### PR TITLE
fix: set org-hide to fixed pitch

### DIFF
--- a/init.el
+++ b/init.el
@@ -258,6 +258,7 @@
   (set-face-attribute 'org-verbatim nil :inherit '(shadow fixed-pitch))
   (set-face-attribute 'org-special-keyword nil :inherit '(font-lock-comment-face fixed-pitch))
   (set-face-attribute 'org-meta-line nil :inherit '(font-lock-comment-face fixed-pitch))
+  (set-face-attribute 'org-hide nil :inherit 'fixed-pitch)
   (set-face-attribute 'org-checkbox nil :inherit 'fixed-pitch))
 
 (use-package org


### PR DESCRIPTION
Fixes indentation when enabling variable-pitch-mode in org.